### PR TITLE
Add Password History and Settings Features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
-        "Pretto"
+        "Pretto",
+        "reduxjs"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "password",
-  "version": "0.1.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "password",
-      "version": "0.1.0",
+      "version": "2.1.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.15",
         "@mui/material": "^5.14.15",
+        "@reduxjs/toolkit": "^1.9.7",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -23,6 +24,7 @@
         "match-sorter": "^6.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^8.1.3",
         "react-router-dom": "^6.17.0",
         "react-scripts": "5.0.1",
         "sort-by": "^1.2.0",
@@ -3695,6 +3697,29 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "dependencies": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
@@ -4468,6 +4493,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.4.tgz",
+      "integrity": "sha512-ZchYkbieA+7tnxwX/SCBySx9WwvWR8TaP5tb2jRAzwvLb/rWchGw3v0w3pqUbUvj0GCwW2Xz/AVPSk6kUGctXQ==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -4675,6 +4709,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.5.tgz",
       "integrity": "sha512-I3pkr8j/6tmQtKV/ZzHtuaqYSQvyjGRKH4go60Rr0IDLlFxuRT5V32uvB1mecM5G1EVAUyF/4r4QZ1GHgz+mxA=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.8",
@@ -15020,6 +15059,49 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -15200,6 +15282,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -15349,6 +15447,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -17229,6 +17332,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -20674,6 +20785,17 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
+    "@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "requires": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      }
+    },
     "@remix-run/router": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
@@ -21235,6 +21357,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.4.tgz",
+      "integrity": "sha512-ZchYkbieA+7tnxwX/SCBySx9WwvWR8TaP5tb2jRAzwvLb/rWchGw3v0w3pqUbUvj0GCwW2Xz/AVPSk6kUGctXQ==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -21442,6 +21573,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.5.tgz",
       "integrity": "sha512-I3pkr8j/6tmQtKV/ZzHtuaqYSQvyjGRKH4go60Rr0IDLlFxuRT5V32uvB1mecM5G1EVAUyF/4r4QZ1GHgz+mxA=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/ws": {
       "version": "8.5.8",
@@ -28764,6 +28900,26 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -28895,6 +29051,20 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "requires": {}
+    },
     "reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
@@ -29013,6 +29183,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "resolve": {
       "version": "1.22.8",
@@ -30382,6 +30557,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "password",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.15",
     "@mui/material": "^5.14.15",
+    "@reduxjs/toolkit": "^1.9.7",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -18,6 +19,7 @@
     "match-sorter": "^6.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^8.1.3",
     "react-router-dom": "^6.17.0",
     "react-scripts": "5.0.1",
     "sort-by": "^1.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { PaletteMode } from "@mui/material";
 import { useMemo, useState } from "react";
+import { Provider } from "react-redux";
+import { store } from "./RTK/store";
 
 import ColorModeContext from "./context/ThemeContext";
 import NotFound from "./components/Error/NotFound";
@@ -10,7 +13,6 @@ import Layout from "./layout";
 import Main from "./main";
 
 import "./App.css";
-import { PaletteMode } from "@mui/material";
 
 const router = createBrowserRouter([
   {
@@ -67,9 +69,11 @@ export default function App() {
 
   return (
     <ColorModeContext.Provider value={colorMode}>
-      <ThemeProvider theme={theme}>
-        <RouterProvider router={router} />
-      </ThemeProvider>
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <RouterProvider router={router} />
+        </ThemeProvider>
+      </Provider>
     </ColorModeContext.Provider>
   );
 }

--- a/src/RTK/slices/history.ts
+++ b/src/RTK/slices/history.ts
@@ -1,0 +1,37 @@
+import { ProPasswordReturnType } from "../../components/types/PasswordAttributesType";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+
+// historyItem.ts
+export interface HistoryItem extends ProPasswordReturnType {
+  // Define the properties of a history item here
+  time: string;
+}
+
+const historySlice = createSlice({
+  name: "history",
+  initialState: [] as HistoryItem[],
+  reducers: {
+    addHistory: (state, action: PayloadAction<HistoryItem>) => {
+      // Add the new history item to the start of the array
+      state.unshift(action.payload);
+    },
+    removeHistory: (state, action: PayloadAction<string[]>) => {
+      // Remove the history items whose time property is included in the action payload
+      return state.filter((item) => !action.payload.includes(item.time));
+    },
+  },
+});
+
+const historyProps = createSlice({
+  name: "historyProps",
+  initialState: { menu: false, bookmark: true },
+  reducers: {
+    toggleHistoryBookmark: (state, action: PayloadAction<boolean>) => {
+      return { ...state, bookmark: action.payload };
+    },
+  },
+});
+
+export const { addHistory, removeHistory } = historySlice.actions;
+export const { toggleHistoryBookmark } = historyProps.actions;
+export { historySlice, historyProps };

--- a/src/RTK/slices/setting.ts
+++ b/src/RTK/slices/setting.ts
@@ -1,0 +1,28 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+
+export interface SettingState {
+  dark: boolean;
+  salt: boolean;
+}
+
+const initialState: SettingState = {
+  dark: false,
+  salt: false,
+};
+
+const settingProps = createSlice({
+  name: "settingProps",
+  initialState,
+  reducers: {
+    setTheme: (state, action: PayloadAction<boolean>) => {
+      return { ...state, dark: action.payload };
+    },
+    setSalt: (state, action: PayloadAction<boolean>) => {
+      return { ...state, salt: action.payload };
+    },
+  },
+});
+
+export const { setTheme, setSalt } = settingProps.actions;
+
+export default settingProps.reducer;

--- a/src/RTK/slices/toggleWindow.ts
+++ b/src/RTK/slices/toggleWindow.ts
@@ -1,0 +1,15 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+
+const toggleWindowSlice = createSlice({
+  name: "toggleWindow",
+  initialState: "",
+  reducers: {
+    setWindowName: (state, action: PayloadAction<string>) => {
+      // This will toggle the specific key in the state
+      return action.payload;
+    },
+  },
+});
+
+export const { setWindowName } = toggleWindowSlice.actions;
+export default toggleWindowSlice.reducer;

--- a/src/RTK/store.ts
+++ b/src/RTK/store.ts
@@ -1,0 +1,19 @@
+import { historySlice, historyProps } from "./slices/history";
+import { configureStore } from "@reduxjs/toolkit";
+
+import toggleWindowSlice from "./slices/toggleWindow";
+import settingProps from "./slices/setting";
+
+export const store = configureStore({
+  reducer: {
+    history: historySlice.reducer,
+    historyProps: historyProps.reducer,
+    settingProps: settingProps,
+    activeWindow: toggleWindowSlice,
+  },
+});
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>;
+// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+export type AppDispatch = typeof store.dispatch;

--- a/src/RTK/type.ts
+++ b/src/RTK/type.ts
@@ -1,0 +1,4 @@
+const HISTORY = "history";
+const SETTINGS = "settings";
+
+export { HISTORY, SETTINGS };

--- a/src/components/buttons/WindowBack.tsx
+++ b/src/components/buttons/WindowBack.tsx
@@ -1,0 +1,16 @@
+import { setWindowName } from "../../RTK/slices/toggleWindow";
+import { useDispatch } from "react-redux";
+
+import NavigateBeforeIcon from "@mui/icons-material/NavigateBefore";
+import IconButton from "@mui/material/IconButton";
+
+function WindowBack() {
+  const dispatch = useDispatch();
+  return (
+    <IconButton title="Back" onClick={() => dispatch(setWindowName(""))}>
+      <NavigateBeforeIcon />
+    </IconButton>
+  );
+}
+
+export default WindowBack;

--- a/src/components/password/PasswordGenerator.tsx
+++ b/src/components/password/PasswordGenerator.tsx
@@ -1,8 +1,7 @@
-import { Suspense, lazy, useState } from "react";
+import { useState } from "react";
 import {
   Button,
   Checkbox,
-  Container,
   FormControl,
   FormControlLabel,
   FormLabel,
@@ -17,24 +16,19 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import {
-  PasswordAttributesType,
-  ProPasswordReturnType,
-} from "../types/PasswordAttributesType";
+import { PasswordAttributesType } from "../types/PasswordAttributesType";
+import { useDispatch, useSelector } from "react-redux";
+import { addHistory } from "../../RTK/slices/history";
+import { RootState } from "../../RTK/store";
 
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 import RotateLeftIcon from "@mui/icons-material/RotateLeft";
 import generatePassword from "../../utils/generatePassword";
 import copyToClipboard from "../../utils/copyToClipboard";
 import CachedIcon from "@mui/icons-material/Cached";
 import Typography from "@mui/material/Typography";
-import ThemeSwitch from "../buttons/ThemeSwitch";
 import InfoIcon from "@mui/icons-material/Info";
 import Box from "@mui/material/Box";
-
-const TwitterShare = lazy(() => import("../buttons/TwitterShare"));
-const Appreciate = lazy(() => import("../thanks/Appreciate"));
 
 const PrettoSlider = styled(Slider)({
   // color: "rgb(0, 0, 155)",
@@ -76,7 +70,12 @@ const PrettoSlider = styled(Slider)({
 
 function PasswordGenerator() {
   const theme = useTheme();
-  const [settings, setSettings] = useState(false);
+  const dispatch = useDispatch();
+  const {
+    history,
+    activeWindow,
+    settingProps: { salt },
+  } = useSelector((state: RootState) => state);
   const [pp, setPP] = useState<PasswordAttributesType>({
     upper: true,
     lower: true,
@@ -87,18 +86,8 @@ function PasswordGenerator() {
     saltAt: "e",
   });
   const [isCopy, setCopy] = useState(false);
-  const [password, setPassword] = useState<ProPasswordReturnType>({
-    password: "",
-    strength: {
-      message: "",
-      color: "",
-      level: 0,
-    },
-  });
 
   const small = useMediaQuery(theme.breakpoints.down("sm"));
-  // const medium = useMediaQuery(theme.breakpoints.between("sm", "md"));
-  // const large = useMediaQuery(theme.breakpoints.up("lg"));
 
   const mode = theme.palette.mode;
   const palette = theme.palette;
@@ -107,10 +96,13 @@ function PasswordGenerator() {
   }`;
 
   const handlePP = () => {
+    const t = new Date();
     const x = generatePassword(pp);
-    setPassword(x);
+    dispatch(addHistory({ ...x, time: t.toISOString() }));
     setCopy(false);
+    console.log(history);
   };
+
   const handleReset = () => {
     setPP((prev) => ({
       ...prev,
@@ -124,8 +116,9 @@ function PasswordGenerator() {
     }));
     setCopy(false);
   };
+
   const handleCopy = async () => {
-    const x = await copyToClipboard(password.password);
+    const x = await copyToClipboard(history[0]?.password);
     setCopy(x);
 
     setTimeout(() => {
@@ -135,317 +128,257 @@ function PasswordGenerator() {
 
   return (
     <>
-      <Container maxWidth={"sm"}>
-        <Paper
-          elevation={8}
-          sx={{
-            borderRadius: 6,
-            p: 1,
-            background: palette.background.default,
-            opacity: 1,
-          }}
-        >
+      <Paper
+        elevation={0}
+        sx={{
+          borderRadius: 4,
+          backgroundColor: palette.background.paper,
+          height: "100%",
+          width: "100%",
+          position: "relative",
+          left: activeWindow ? "-100%" : "0%",
+          transition: ".3s",
+        }}
+      >
+        <Stack spacing={1} sx={{ p: 1 }}>
           <Box
             sx={{
+              p: 1,
+              borderRadius: 2,
+              background: "transparent",
+              border: 2,
               display: "flex",
               justifyContent: "space-between",
               alignItems: "center",
-              py: 2,
-              px: small ? 1 : 2,
+              boxShadow: boxShadow,
+            }}
+          >
+            <Typography
+              variant="body1"
+              sx={{ fontSize: "1rem", fontWeight: "bold" }}
+            >
+              {history[0]?.password}
+            </Typography>
+            <IconButton
+              onClick={handleCopy}
+              title={`${isCopy ? "Copied" : "Copy"}`}
+              sx={{
+                p: ".5",
+                m: 0,
+                minWidth: "0",
+                borderRadius: 2,
+                color: `${isCopy ? "green" : ""}`,
+                display: "flex",
+                alignItems: "center",
+              }}
+            >
+              <ContentPasteIcon />
+            </IconButton>
+          </Box>
+          <Typography
+            variant="body2"
+            px={1}
+            color={history[0]?.strength.color}
+            sx={{ display: "flex", alignItems: "center", gap: 1 }}
+          >
+            {history[0]?.strength.message && <InfoIcon />}
+            {history[0]?.strength.message}
+          </Typography>
+          <Box
+            sx={{
+              p: 2,
+              borderRadius: 2,
+              boxShadow: boxShadow,
             }}
           >
             <Box
               sx={{
                 display: "flex",
+                justifyContent: "space-between",
                 alignItems: "center",
-                justifyContent: "center",
-                gap: 1,
               }}
             >
-              <img src="/logo32.png" alt="brand logo" width={24} />
-              <Typography
-                variant="h1"
-                sx={{
-                  fontSize: "1rem",
-                  fontWeight: "bold",
-                  textAlign: "center",
-                }}
-              >
-                Password Generator
-              </Typography>
-            </Box>
-
-            <Suspense>
-              <Box>
-                <TwitterShare />
-                <ThemeSwitch />
-              </Box>
-            </Suspense>
-          </Box>
-
-          <Paper
-            elevation={0}
-            sx={{
-              borderRadius: 4,
-              backgroundColor: palette.background.paper,
-            }}
-          >
-            <Stack spacing={1} sx={{ p: 1 }}>
-              <Box
-                sx={{
-                  p: 1,
-                  borderRadius: 2,
-                  background: "transparent",
-                  border: 2,
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  boxShadow: boxShadow,
-                }}
-              >
+              <div>
+                Password length{" "}
                 <Typography
-                  variant="body1"
-                  sx={{ fontSize: "1rem", fontWeight: "bold" }}
-                >
-                  {password.password}
-                </Typography>
-                <IconButton
-                  onClick={handleCopy}
-                  title={`${isCopy ? "Copied" : "Copy"}`}
+                  variant="body2"
                   sx={{
-                    p: ".5",
-                    m: 0,
-                    minWidth: "0",
-                    borderRadius: 2,
-                    color: `${isCopy ? "green" : ""}`,
-                    display: "flex",
-                    alignItems: "center",
-                  }}
-                >
-                  <ContentPasteIcon />
-                </IconButton>
-              </Box>
-              <Typography
-                variant="body2"
-                px={1}
-                color={password.strength.color}
-                sx={{ display: "flex", alignItems: "center", gap: 1 }}
-              >
-                {password.strength.message && <InfoIcon />}
-                {password.strength.message}
-              </Typography>
-              <Box
-                sx={{
-                  p: 2,
-                  borderRadius: 2,
-                  boxShadow: boxShadow,
-                }}
-              >
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <div>
-                    Password length{" "}
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        display: "inline",
-                        fontWeight: "bold",
-                        bgcolor: palette.text.primary,
-                        color: palette.background.default,
-                        p: 0.5,
-                        borderRadius: "100%",
-                      }}
-                    >
-                      {pp.length}
-                    </Typography>
-                  </div>
-                  <Button
-                    variant="contained"
-                    onClick={handleReset}
-                    sx={{
-                      gap: 1,
-                      borderRadius: 2,
-                      minWidth: 0,
-                      p: small ? 0.5 : "auto",
-                      fontWeight: "bold",
-                    }}
-                  >
-                    {!small && "Reset"}
-                    <RotateLeftIcon />
-                  </Button>
-                </Box>
-                <PrettoSlider
-                  valueLabelDisplay="auto"
-                  aria-label="password length"
-                  value={pp.length}
-                  min={1}
-                  max={32}
-                  sx={{
-                    pt: 3,
-                    ".MuiSlider-valueLabel": {
-                      backgroundColor: palette.primary.main,
-                    },
-                  }}
-                  onChange={(e, nValue) =>
-                    setPP((prev) => ({ ...prev, length: nValue }))
-                  }
-                />
-              </Box>
-              <FormControlLabel
-                control={<Checkbox />}
-                label="Uppercase (A-Z)"
-                labelPlacement="start"
-                checked={pp.upper}
-                onChange={() =>
-                  setPP((prev) => ({ ...prev, upper: !prev.upper }))
-                }
-                sx={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  pl: 1,
-                  borderRadius: 2,
-                  boxShadow: boxShadow,
-                }}
-              />
-              <FormControlLabel
-                control={<Checkbox />}
-                label="Lowercase (a-z)"
-                labelPlacement="start"
-                checked={pp.lower}
-                onChange={() =>
-                  setPP((prev) => ({ ...prev, lower: !prev.lower }))
-                }
-                sx={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  pl: 1,
-                  borderRadius: 2,
-                  boxShadow: boxShadow,
-                }}
-              />
-              <FormControlLabel
-                control={<Checkbox />}
-                label="Symbols (!@#$)"
-                labelPlacement="start"
-                checked={pp.symbol}
-                onChange={() =>
-                  setPP((prev) => ({ ...prev, symbol: !prev.symbol }))
-                }
-                sx={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  pl: 1,
-                  borderRadius: 2,
-                  boxShadow: boxShadow,
-                }}
-              />
-              <FormControlLabel
-                control={<Checkbox />}
-                label="Numbers (0-9)"
-                labelPlacement="start"
-                checked={pp.number}
-                onChange={() =>
-                  setPP((prev) => ({ ...prev, number: !prev.number }))
-                }
-                sx={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  pl: 1,
-                  borderRadius: 2,
-                  boxShadow: boxShadow,
-                }}
-              />
-              <Box
-                sx={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  p: 1,
-                }}
-              >
-                <Typography variant="body1">Advance Settings</Typography>
-                <Button
-                  variant="contained"
-                  title={`${settings ? "Hide" : "Show"} advanced settings`}
-                  onClick={() => setSettings(!settings)}
-                  sx={{
-                    gap: 1,
-                    borderRadius: 2,
-                    minWidth: "fit-content",
+                    display: "inline",
+                    fontWeight: "bold",
+                    bgcolor: palette.text.primary,
+                    color: palette.background.default,
                     p: 0.5,
+                    borderRadius: "100%",
                   }}
                 >
-                  <KeyboardArrowDownIcon
-                    sx={{ rotate: settings ? "180deg" : 0, transition: ".3s" }}
-                  />
-                </Button>
-              </Box>
-              {settings && (
-                <Box sx={{ borderRadius: 2, p: 1 }}>
-                  <TextField
-                    id="outlined-basic"
-                    label="Add Salt"
-                    variant="outlined"
-                    value={pp.salt}
-                    onChange={(e) =>
-                      setPP((prev) => ({ ...prev, salt: e.target.value }))
-                    }
-                    sx={{ width: "100%" }}
-                  />
-                  <FormControl sx={{ p: 1, pt: 2 }}>
-                    <FormLabel id="demo-row-radio-buttons-group-label">
-                      Position
-                    </FormLabel>
-                    <RadioGroup
-                      row
-                      // defaultValue={"e"}
-                      value={pp.saltAt}
-                      onChange={(e) =>
-                        setPP((prev) => ({ ...prev, saltAt: e.target.value }))
-                      }
-                      aria-labelledby="demo-row-radio-buttons-group-label"
-                      name="row-radio-buttons-group"
-                    >
-                      <FormControlLabel
-                        value="s"
-                        control={<Radio />}
-                        label="Start"
-                      />
-                      <FormControlLabel
-                        value="b"
-                        control={<Radio />}
-                        label="Between"
-                      />
-                      <FormControlLabel
-                        value="e"
-                        control={<Radio />}
-                        label="End"
-                      />
-                    </RadioGroup>
-                  </FormControl>
-                </Box>
-              )}
-              <hr style={{ opacity: ".1" }} />
+                  {pp.length}
+                </Typography>
+              </div>
               <Button
                 variant="contained"
-                endIcon={<CachedIcon />}
-                onClick={handlePP}
-                sx={{ borderRadius: 2, fontWeight: "bold", py: 1 }}
+                onClick={handleReset}
+                sx={{
+                  gap: 1,
+                  borderRadius: 2,
+                  minWidth: 0,
+                  p: small ? 0.5 : "auto",
+                  fontWeight: "bold",
+                }}
               >
-                Generate Password
+                {!small && "Reset"}
+                <RotateLeftIcon />
               </Button>
-            </Stack>
-          </Paper>
-        </Paper>
-      </Container>
-      <Suspense>
-        <Appreciate />
-      </Suspense>
+            </Box>
+            <PrettoSlider
+              valueLabelDisplay="auto"
+              aria-label="password length"
+              value={pp.length}
+              min={1}
+              max={32}
+              sx={{
+                pt: 3,
+                ".MuiSlider-valueLabel": {
+                  backgroundColor: palette.primary.main,
+                },
+              }}
+              onChange={(e, nValue) =>
+                setPP((prev) => ({ ...prev, length: nValue }))
+              }
+            />
+          </Box>
+          <FormControlLabel
+            control={<Checkbox />}
+            label="Uppercase (A-Z)"
+            labelPlacement="start"
+            checked={pp.upper}
+            onChange={() => setPP((prev) => ({ ...prev, upper: !prev.upper }))}
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              pl: 1,
+              borderRadius: 2,
+              boxShadow: boxShadow,
+            }}
+          />
+          <FormControlLabel
+            control={<Checkbox />}
+            label="Lowercase (a-z)"
+            labelPlacement="start"
+            checked={pp.lower}
+            onChange={() => setPP((prev) => ({ ...prev, lower: !prev.lower }))}
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              pl: 1,
+              borderRadius: 2,
+              boxShadow: boxShadow,
+            }}
+          />
+          <FormControlLabel
+            control={<Checkbox />}
+            label="Symbols (!@#$)"
+            labelPlacement="start"
+            checked={pp.symbol}
+            onChange={() =>
+              setPP((prev) => ({ ...prev, symbol: !prev.symbol }))
+            }
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              pl: 1,
+              borderRadius: 2,
+              boxShadow: boxShadow,
+            }}
+          />
+          <FormControlLabel
+            control={<Checkbox />}
+            label="Numbers (0-9)"
+            labelPlacement="start"
+            checked={pp.number}
+            onChange={() =>
+              setPP((prev) => ({ ...prev, number: !prev.number }))
+            }
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              pl: 1,
+              borderRadius: 2,
+              boxShadow: boxShadow,
+            }}
+          />
+
+          {salt && (
+            <>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  p: 1,
+                }}
+              >
+                <Typography variant="body1" fontWeight={"bold"}>
+                  Advance Settings
+                </Typography>
+              </Box>
+
+              <Box sx={{ borderRadius: 2, p: 1 }}>
+                <TextField
+                  id="outlined-basic"
+                  label="Add Salt"
+                  variant="outlined"
+                  value={pp.salt}
+                  onChange={(e) =>
+                    setPP((prev) => ({ ...prev, salt: e.target.value }))
+                  }
+                  sx={{ width: "100%" }}
+                />
+                <FormControl sx={{ p: 1, pt: 2 }}>
+                  <FormLabel id="demo-row-radio-buttons-group-label">
+                    Position
+                  </FormLabel>
+                  <RadioGroup
+                    row
+                    // defaultValue={"e"}
+                    value={pp.saltAt}
+                    onChange={(e) =>
+                      setPP((prev) => ({ ...prev, saltAt: e.target.value }))
+                    }
+                    aria-labelledby="demo-row-radio-buttons-group-label"
+                    name="row-radio-buttons-group"
+                  >
+                    <FormControlLabel
+                      value="s"
+                      control={<Radio />}
+                      label="Start"
+                    />
+                    <FormControlLabel
+                      value="b"
+                      control={<Radio />}
+                      label="Between"
+                    />
+                    <FormControlLabel
+                      value="e"
+                      control={<Radio />}
+                      label="End"
+                    />
+                  </RadioGroup>
+                </FormControl>
+              </Box>
+            </>
+          )}
+          {/**/}
+          <hr style={{ opacity: ".1" }} />
+          <Button
+            variant="contained"
+            endIcon={<CachedIcon />}
+            onClick={handlePP}
+            sx={{ borderRadius: 2, fontWeight: "bold", py: 1 }}
+          >
+            Generate Password
+          </Button>
+        </Stack>
+      </Paper>
     </>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,16 @@
+import { useTheme } from "@mui/material";
 import { Suspense, lazy } from "react";
 
+import useMediaQuery from "@mui/material/useMediaQuery";
 import InitialScreen from "./initialScreen";
 import Box from "@mui/material/Box";
 
-const PasswordGenerator = lazy(
-  () => import("./components/password/PasswordGenerator")
-  );
+const Home = lazy(() => import("./pages/Home"));
 
 function Main() {
+  const theme = useTheme();
+  const small = useMediaQuery(theme.breakpoints.down("sm"));
+
   return (
     <Box
       sx={{
@@ -21,8 +24,8 @@ function Main() {
       }}
     >
       <Suspense fallback={<InitialScreen />}>
-        <Box sx={{ height: "3rem" }}></Box>
-        <PasswordGenerator />
+        <Box sx={{ height: small ? "1rem" : "3rem" }}></Box>
+        <Home />
       </Suspense>
     </Box>
   );

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,0 +1,177 @@
+import {
+  Box,
+  Button,
+  Checkbox,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { removeHistory } from "../RTK/slices/history";
+import { RootState } from "../RTK/store";
+import { useState } from "react";
+
+import WindowBack from "../components/buttons/WindowBack";
+import DeleteIcon from "@mui/icons-material/Delete";
+import Paper from "@mui/material/Paper";
+
+function History() {
+  const theme = useTheme();
+  const dispatch = useDispatch();
+  const [selectHistoryItem, setHistoryItem] = useState<string[]>([]);
+  const { history, activeWindow } = useSelector((state: RootState) => state);
+  const small = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const palette = theme.palette;
+
+  return (
+    <>
+      <Paper
+        elevation={0}
+        sx={{
+          borderRadius: 4,
+          backgroundColor: palette.background.paper,
+          position: "absolute",
+          top: 0,
+          width: "100%",
+          left: activeWindow === "history" ? "0" : "100%",
+          transition: ".3s",
+          height: "100%",
+          zIndex: activeWindow === "history" ? 5 : 0,
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            p: 1,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            <WindowBack />
+            <Typography
+              variant="h2"
+              sx={{
+                display: "inline",
+                fontWeight: "bold",
+                fontSize: "1rem",
+                pr: 1,
+              }}
+            >
+              History
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                display: "inline",
+                fontWeight: "bold",
+                bgcolor: palette.text.primary,
+                color: palette.background.default,
+                p: 0.5,
+                borderRadius: "100%",
+              }}
+            >
+              {history.length}
+            </Typography>
+          </Box>
+          <Button
+            variant="contained"
+            onClick={() => dispatch(removeHistory(selectHistoryItem))}
+            title="Delete history"
+            sx={{
+              gap: 1,
+              borderRadius: 2,
+              minWidth: 0,
+              bgcolor: "red",
+              p: small ? 0.5 : "auto",
+              fontWeight: "bold",
+              ":hover": { bgcolor: "rgb(140, 0, 0)" },
+            }}
+          >
+            {!small && "Delete"}
+            <DeleteIcon />
+          </Button>
+        </Box>
+        <hr style={{ opacity: 0.1 }} />
+        {history?.length === 0 ? (
+          <Typography sx={{ p: 2, textAlign: "center" }}>
+            No record found.
+          </Typography>
+        ) : (
+          <List dense sx={{ width: "100%", overflowY: "auto" }}>
+            {history.map((item, i) => {
+              const time = new Date(item.time);
+              return (
+                item.password.length > 0 && (
+                  <ListItem
+                    alignItems="flex-start"
+                    key={i}
+                    sx={{
+                      borderBottom: 0.5,
+                      borderColor: "rgb(150, 150, 150, .1)",
+                    }}
+                  >
+                    <ListItemText
+                      primary={
+                        <span
+                          style={{
+                            fontWeight: "bold",
+                            paddingBottom: ".5rem",
+                            fontSize: "1rem",
+                          }}
+                        >
+                          {item.password}
+                        </span>
+                      }
+                      sx={{ fontSize: "1rem", fontWeight: "bold" }}
+                      secondary={
+                        <>
+                          <Typography
+                            sx={{ display: "inline" }}
+                            component="span"
+                            variant="body2"
+                            color="text.primary"
+                            fontSize={"0.8rem"}
+                          >
+                            {"Password strength —  "}
+                          </Typography>
+                          <span
+                            style={{
+                              display: "inline",
+                              color: item.strength.color,
+                            }}
+                          >
+                            {item.strength.message}
+                          </span>
+                          <span style={{ opacity: 0.7, display: "block" }}>
+                            Time:- {time.toLocaleTimeString()}
+                          </span>
+                        </>
+                      }
+                    />
+                    <Checkbox
+                      checked={selectHistoryItem.includes(item.time)}
+                      onChange={() =>
+                        setHistoryItem((prev) => [...prev, item.time])
+                      }
+                      inputProps={{ "aria-label": "controlled" }}
+                    />
+                  </ListItem>
+                )
+              );
+            })}
+          </List>
+        )}
+      </Paper>
+    </>
+  );
+}
+
+export default History;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,116 @@
+import { Container, IconButton, Paper, useTheme } from "@mui/material";
+import { setWindowName } from "../RTK/slices/toggleWindow";
+import { useDispatch, useSelector } from "react-redux";
+import { HISTORY, SETTINGS } from "../RTK/type";
+import { RootState } from "../RTK/store";
+import { Suspense, lazy } from "react";
+
+import PasswordGenerator from "../components/password/PasswordGenerator";
+import Appreciate from "../components/thanks/Appreciate";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import SettingsIcon from "@mui/icons-material/Settings";
+import HistoryIcon from "@mui/icons-material/History";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import Settings from "./Settings";
+import History from "./History";
+
+const TwitterShare = lazy(() => import("../components/buttons/TwitterShare"));
+
+function Home() {
+  const theme = useTheme();
+  const small = useMediaQuery(theme.breakpoints.down("sm"));
+  const dispatch = useDispatch();
+  const {
+    historyProps: { bookmark },
+  } = useSelector((state: RootState) => state);
+
+  const palette = theme.palette;
+
+  return (
+    <>
+      <Container maxWidth={"sm"}>
+        <Paper
+          elevation={8}
+          sx={{
+            borderRadius: 6,
+            p: 1,
+            background: palette.background.default,
+            opacity: 1,
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              py: 2,
+              px: small ? 1 : 2,
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 1,
+              }}
+            >
+              <img src="/logo32.png" alt="brand logo" width={24} />
+              <Typography
+                variant="h1"
+                sx={{
+                  fontSize: "1rem",
+                  fontWeight: "bold",
+                  textAlign: "center",
+                }}
+              >
+                Password Generator
+              </Typography>
+            </Box>
+
+            <Suspense>
+              <Box>
+                <TwitterShare />
+                {bookmark && (
+                  <IconButton
+                    title="History"
+                    onClick={() => dispatch(setWindowName(HISTORY))}
+                  >
+                    <HistoryIcon />
+                  </IconButton>
+                )}
+                <IconButton
+                  title="Settings"
+                  onClick={() => dispatch(setWindowName(SETTINGS))}
+                >
+                  <SettingsIcon />
+                </IconButton>
+              </Box>
+            </Suspense>
+          </Box>
+
+          {/* --------------------- */}
+          <Box
+            sx={{
+              minHeight: "400px",
+              // height: "100%",
+              overflow: "hidden",
+              position: "relative",
+            }}
+          >
+            <PasswordGenerator />
+            <History />
+            <Settings />
+          </Box>
+          {/* --------------------- */}
+        </Paper>
+      </Container>
+      <Suspense>
+        <Appreciate />
+      </Suspense>
+    </>
+  );
+}
+
+export default Home;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,154 @@
+import {
+  Checkbox,
+  List,
+  ListItem,
+  ListItemText,
+  useTheme,
+} from "@mui/material";
+import { toggleHistoryBookmark } from "../RTK/slices/history";
+import { useDispatch, useSelector } from "react-redux";
+import { setSalt } from "../RTK/slices/setting";
+import { RootState } from "../RTK/store";
+
+import ThemeSwitch from "../components/buttons/ThemeSwitch";
+import WindowBack from "../components/buttons/WindowBack";
+import Typography from "@mui/material/Typography";
+import Paper from "@mui/material/Paper";
+import Box from "@mui/material/Box";
+import React from "react";
+
+function Settings() {
+  const theme = useTheme();
+  const dispatch = useDispatch();
+  const {
+    historyProps: { bookmark },
+    activeWindow,
+    settingProps: { salt },
+  } = useSelector((state: RootState) => state);
+
+  const palette = theme.palette;
+
+  return (
+    <>
+      <Paper
+        elevation={0}
+        sx={{
+          borderRadius: 4,
+          backgroundColor: palette.background.paper,
+          position: "absolute",
+          top: 0,
+          width: "100%",
+          left: activeWindow === "settings" ? "0" : "100%",
+          transition: ".3s",
+          height: "100%",
+          zIndex: activeWindow === "settings" ? 5 : 0,
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            p: 1,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            <WindowBack />
+            <Typography
+              variant="h2"
+              sx={{ fontSize: "1rem", fontWeight: "bold", pl: 1 }}
+            >
+              Settings
+            </Typography>
+          </Box>
+        </Box>
+        <hr style={{ opacity: 0.1 }} />
+        <Box sx={{}}>
+          <List sx={{ width: "100%", bgcolor: "background.paper" }}>
+            <ListItem alignItems="flex-start">
+              <ListItemText
+                primary="Theme"
+                secondary={
+                  <React.Fragment>
+                    <Typography
+                      sx={{ display: "inline" }}
+                      component="span"
+                      variant="body2"
+                      color="text.primary"
+                    >
+                      Dark Mode
+                    </Typography>
+                    {" — Toggle to activate dark and light mode…"}
+                  </React.Fragment>
+                }
+              />
+              <ThemeSwitch />
+            </ListItem>
+            {/* <Divider component="li" /> */}
+            <ListItem
+              alignItems="flex-start"
+              sx={{ borderBottom: 1, borderColor: "rgb(150, 150, 150, .3)" }}
+            >
+              <ListItemText
+                primary="History"
+                secondary={
+                  <React.Fragment>
+                    <Typography
+                      sx={{ display: "inline" }}
+                      component="span"
+                      variant="body2"
+                      color="text.primary"
+                    >
+                      Password history
+                    </Typography>
+                    {" — Bookmark history button on the header..."}
+                  </React.Fragment>
+                }
+              />
+              <Checkbox
+                checked={bookmark}
+                onChange={() => dispatch(toggleHistoryBookmark(!bookmark))}
+                inputProps={{ "aria-label": "controlled" }}
+              />
+            </ListItem>
+            <ListItem>
+              <Typography
+                variant="h3"
+                sx={{ fontWeight: "bold", mt: 1, fontSize: "1rem" }}
+              >
+                Advance Settings
+              </Typography>
+            </ListItem>
+            <ListItem alignItems="flex-start">
+              <ListItemText
+                primary="Salt"
+                secondary={
+                  <React.Fragment>
+                    <Typography
+                      sx={{ display: "inline" }}
+                      component="span"
+                      variant="body2"
+                      color="text.primary"
+                    >
+                      Salt string
+                    </Typography>
+                    {
+                      " — A custom string added to the password before hashing for enhanced security..."
+                    }
+                  </React.Fragment>
+                }
+              />
+              <Checkbox
+                checked={salt}
+                onChange={() => dispatch(setSalt(!salt))}
+                inputProps={{ "aria-label": "controlled" }}
+              />
+            </ListItem>
+          </List>
+        </Box>
+      </Paper>
+    </>
+  );
+}
+
+export default Settings;


### PR DESCRIPTION
**Title:** Add Password History and Settings Features

Hello,

I've implemented the "Password History" and "Settings" features as discussed in the feature request. Here are the details of the changes:

**Changes Made:**

1. Added a new state variable to store the history of generated passwords.
2. Created a new component to display the password history.
3. Integrated the password history component into the main password generator component.
4. Added functionality to update the password history state whenever a new password is generated.
5. Added a delete history functionality that allows users to clear their password history.
6. Created a new "Settings" component that includes theme settings and a toggle for the password salt option.
7. Moved the password salt option from the main password generator component to the "Settings" component.
8. Added a "History" button to the header, which is displayed by default.

**How to Test:**

1. Generate a new password and check if it appears in the password history section.
2. Use the delete history functionality and ensure that the password history is cleared.
3. Navigate to the "Settings" component and test the theme settings and password salt option.
4. Ensure that the "History" button is displayed in the header by default.

I believe these features enhance the user experience by providing more customization options and a way to access and manage previously generated passwords. I've thoroughly tested these changes and everything seems to be working well. However, I'd appreciate if you could review my code and provide any feedback.

Thank you for considering this pull request. I'm looking forward to your feedback.

Best,
@0ME9A 