### PR TITLE
Add Copy Button in History List, improved history header 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "password",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.1",

--- a/src/components/password/PasswordGenerator.tsx
+++ b/src/components/password/PasswordGenerator.tsx
@@ -118,8 +118,7 @@ function PasswordGenerator() {
   };
 
   const handleCopy = async () => {
-    const x = await copyToClipboard(history[0]?.password);
-    setCopy(x);
+    setCopy(await copyToClipboard(history[0]?.password));
 
     setTimeout(() => {
       setCopy(false);
@@ -198,22 +197,25 @@ function PasswordGenerator() {
                 alignItems: "center",
               }}
             >
-              <div>
-                Password length{" "}
-                <Typography
-                  variant="body2"
-                  sx={{
-                    display: "inline",
-                    fontWeight: "bold",
-                    bgcolor: palette.text.primary,
-                    color: palette.background.default,
-                    p: 0.5,
-                    borderRadius: "100%",
+              <Typography
+                variant="h3"
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  fontSize: "1rem",
+                }}
+              >
+                Password length
+                <span
+                  style={{
+                    display: "inline-block",
+                    height: "1.5rem",
+                    border: "1px solid rgb(150, 150, 150, .2)",
                   }}
-                >
-                  {pp.length}
-                </Typography>
-              </div>
+                ></span>
+                {pp.length}
+              </Typography>
               <Button
                 variant="contained"
                 onClick={handleReset}

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   Checkbox,
+  IconButton,
   List,
   ListItem,
   ListItemText,
@@ -14,18 +15,47 @@ import { removeHistory } from "../RTK/slices/history";
 import { RootState } from "../RTK/store";
 import { useState } from "react";
 
+import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 import WindowBack from "../components/buttons/WindowBack";
+import copyToClipboard from "../utils/copyToClipboard";
 import DeleteIcon from "@mui/icons-material/Delete";
 import Paper from "@mui/material/Paper";
+
+interface copyHistoryItemFace {
+  id: string;
+  password: string;
+}
 
 function History() {
   const theme = useTheme();
   const dispatch = useDispatch();
   const [selectHistoryItem, setHistoryItem] = useState<string[]>([]);
+  const [copyPassword, setCopyPassword] = useState<copyHistoryItemFace>({
+    id: "",
+    password: "",
+  });
   const { history, activeWindow } = useSelector((state: RootState) => state);
   const small = useMediaQuery(theme.breakpoints.down("sm"));
 
   const palette = theme.palette;
+
+  const handleHistroyItemSelection = (historyId: string) => {
+    if (selectHistoryItem.includes(historyId)) {
+      const uncheck = selectHistoryItem.filter((id) => id !== historyId);
+      setHistoryItem(uncheck);
+    } else {
+      setHistoryItem((prev) => [...prev, historyId]);
+    }
+  };
+
+  const handleCopy = async ({ id, password }: copyHistoryItemFace) => {
+    await copyToClipboard(password);
+    setCopyPassword({ id, password });
+
+    setTimeout(() => {
+      setCopyPassword({ id: "", password: "" });
+    }, 5000);
+  };
 
   return (
     <>
@@ -59,25 +89,21 @@ function History() {
             <Typography
               variant="h2"
               sx={{
-                display: "inline",
-                fontWeight: "bold",
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
                 fontSize: "1rem",
-                pr: 1,
+                fontWeight: "bold",
               }}
             >
               History
-            </Typography>
-            <Typography
-              variant="body2"
-              sx={{
-                display: "inline",
-                fontWeight: "bold",
-                bgcolor: palette.text.primary,
-                color: palette.background.default,
-                p: 0.5,
-                borderRadius: "100%",
-              }}
-            >
+              <span
+                style={{
+                  display: "inline-block",
+                  height: "1.5rem",
+                  border: "1px solid rgb(150, 150, 150, .2)",
+                }}
+              ></span>
               {history.length}
             </Typography>
           </Box>
@@ -111,7 +137,7 @@ function History() {
               return (
                 item.password.length > 0 && (
                   <ListItem
-                    alignItems="flex-start"
+                    alignItems="center"
                     key={i}
                     sx={{
                       borderBottom: 0.5,
@@ -156,13 +182,48 @@ function History() {
                         </>
                       }
                     />
-                    <Checkbox
-                      checked={selectHistoryItem.includes(item.time)}
-                      onChange={() =>
-                        setHistoryItem((prev) => [...prev, item.time])
-                      }
-                      inputProps={{ "aria-label": "controlled" }}
-                    />
+
+                    <Box
+                      sx={{
+                        display: "flex",
+                        gap: 2,
+                        alignItems: "center",
+                      }}
+                    >
+                      <IconButton
+                        onClick={() =>
+                          handleCopy({ id: item.time, password: item.password })
+                        }
+                        title={`${
+                          copyPassword.id === item.time ? "Copied" : "Copy"
+                        }`}
+                        sx={{
+                          p: ".5",
+                          m: 0,
+                          minWidth: "0",
+                          borderRadius: 2,
+                          color: `${
+                            copyPassword.id === item.time ? "green" : ""
+                          }`,
+                          display: "flex",
+                          alignItems: "center",
+                        }}
+                      >
+                        <ContentPasteIcon />
+                      </IconButton>
+                      <div
+                        style={{
+                          width: "1px",
+                          height: "1.5rem",
+                          backgroundColor: "rgb(150, 150, 150, .5)",
+                        }}
+                      ></div>
+                      <Checkbox
+                        checked={selectHistoryItem.includes(item.time)}
+                        onChange={() => handleHistroyItemSelection(item.time)}
+                        inputProps={{ "aria-label": "controlled" }}
+                      />
+                    </Box>
                   </ListItem>
                 )
               );


### PR DESCRIPTION
**Title:** Add Copy Button in History List

Hello,

I've implemented the "Copy Button in History List" feature as discussed in the feature request. Here are the details of the changes:

**Changes Made:**

1. Added a "Copy" button next to each password in the history list.
2. Used the function (copyToClipboard) to copy the password to the user's clipboard when the "Copy" button is clicked.
3. Improved history window header and main window password length section.
**How to Test:**

1. Generate a new password and check if it appears in the history list with a "Copy" button next to it.
2. Click the "Copy" button and ensure that the password is copied to your clipboard.
3. Paste the copied password somewhere else to verify that the correct password was copied.

I believe this feature enhances the user experience by providing a quick and convenient way to copy passwords from the history list. I've thoroughly tested these changes and everything seems to be working well. However, I'd appreciate it if you could review my code and provide any feedback.

Thank you for considering this pull request. I'm looking forward to your feedback.

Best,
@0ME9A 
