### PR TITLE
fix history 0 out bug in #24

### DIFF
--- a/src/RTK/middleware/localstoremiddleware.ts
+++ b/src/RTK/middleware/localstoremiddleware.ts
@@ -1,0 +1,13 @@
+// localStorageMiddleware.ts
+import { Middleware } from '@reduxjs/toolkit';
+import { RootState } from "../../RTK/store"; 
+
+const localStorageMiddleware: Middleware<{}, RootState> = store => next => action => {
+  const result = next(action);
+
+    localStorage.setItem('passwords', JSON.stringify(store.getState().history));
+
+  return result;
+};
+
+export default localStorageMiddleware;

--- a/src/RTK/slices/history.ts
+++ b/src/RTK/slices/history.ts
@@ -7,9 +7,15 @@ export interface HistoryItem extends ProPasswordReturnType {
   time: string;
 }
 
+const initialState: HistoryItem[] = localStorage.getItem("history")
+  ? JSON.parse(localStorage.getItem("history") || "[]")
+  : [];
+
+console.log(initialState);
+
 const historySlice = createSlice({
   name: "history",
-  initialState: [] as HistoryItem[],
+  initialState: initialState,
   reducers: {
     addHistory: (state, action: PayloadAction<HistoryItem>) => {
       // Add the new history item to the start of the array

--- a/src/RTK/slices/history.ts
+++ b/src/RTK/slices/history.ts
@@ -11,8 +11,6 @@ const initialState: HistoryItem[] = localStorage.getItem("history")
   ? JSON.parse(localStorage.getItem("history") || "[]")
   : [];
 
-console.log(initialState);
-
 const historySlice = createSlice({
   name: "history",
   initialState: initialState,

--- a/src/pages/Tabs/History.tsx
+++ b/src/pages/Tabs/History.tsx
@@ -45,9 +45,7 @@ function History({ page = false }) {
 
   useEffect(() => {
     setHistoryItem([])
-      if(history.length > 0){
-        localStorage.setItem("history", JSON.stringify(history));
-      }
+    localStorage.setItem("history", JSON.stringify(history));
   }, [history]);
 
   const handleHistoryItemSelection = (historyId: string) => {

--- a/src/pages/Tabs/History.tsx
+++ b/src/pages/Tabs/History.tsx
@@ -45,6 +45,9 @@ function History({ page = false }) {
 
   useEffect(() => {
     setHistoryItem([])
+      if(history.length > 0){
+        localStorage.setItem("history", JSON.stringify(history));
+      }
   }, [history]);
 
   const handleHistoryItemSelection = (historyId: string) => {

--- a/src/pages/Tabs/History.tsx
+++ b/src/pages/Tabs/History.tsx
@@ -16,7 +16,7 @@ import { MdOutlineZoomOutMap } from "react-icons/md";
 import { useNavigate } from "react-router-dom";
 import { RootState } from "../../RTK/store";
 import { HISTORY } from "../../RTK/type";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 import WindowBack from "../../components/buttons/WindowBack";
@@ -43,7 +43,11 @@ function History({ page = false }) {
 
   const palette = theme.palette;
 
-  const handleHistroyItemSelection = (historyId: string) => {
+  useEffect(() => {
+    setHistoryItem([])
+  }, [history]);
+
+  const handleHistoryItemSelection = (historyId: string) => {
     if (selectHistoryItem.includes(historyId)) {
       const uncheck = selectHistoryItem.filter((id) => id !== historyId);
       setHistoryItem(uncheck);
@@ -287,7 +291,7 @@ function History({ page = false }) {
                       ></div>
                       <Checkbox
                         checked={selectHistoryItem.includes(item.time)}
-                        onChange={() => handleHistroyItemSelection(item.time)}
+                        onChange={() => handleHistoryItemSelection(item.time)}
                         inputProps={{ "aria-label": "controlled" }}
                       />
                     </Box>


### PR DESCRIPTION
issue #24  explains that their is a bug causing the selected history to not be cleared

I did a use effect linked to the history so that if it gets changed in any way the selected value should also be set to 0
it already clears out when we make a new password so this should be correct 
